### PR TITLE
Update About.xaml.cs

### DIFF
--- a/src/Bluebird/Pages/SettingPages/About.xaml.cs
+++ b/src/Bluebird/Pages/SettingPages/About.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Core;
 
 namespace Bluebird.Pages.SettingPages;
 
@@ -10,5 +10,10 @@ public sealed partial class About : Page
         string appversion = AppVersion.GetAppVersion();
         string coreversion = CoreWebView2Environment.GetAvailableBrowserVersionString();
         VersionText.Text = $"Bluebird {appversion} (core: {coreversion})";
+    }
+
+    private void SettingsBlockControl_Loaded(object sender, RoutedEventArgs e)
+    {
+
     }
 }


### PR DESCRIPTION
Fixed an error where for some reason Visual Studio 2022 refused to compile with spaces on hyperlinks on About.xaml